### PR TITLE
Added missing test cases for account page and input page

### DIFF
--- a/tests/ui/Example_UccLib/account.py
+++ b/tests/ui/Example_UccLib/account.py
@@ -1,18 +1,20 @@
-from ucc_smartx.pages.page import Page
-from ucc_smartx.components.base_component import Selector
-from ucc_smartx.components.tabs import Tab
-from ucc_smartx.components.entity import Entity
-from ucc_smartx.components.controls.button import Button
-from ucc_smartx.components.controls.single_select import SingleSelect
-from ucc_smartx.components.controls.oauth_select import OAuthSelect
-from ucc_smartx.components.controls.multi_select import MultiSelect
-from ucc_smartx.components.controls.checkbox import Checkbox
-from ucc_smartx.components.controls.toggle import Toggle
-from ucc_smartx.components.controls.textbox import TextBox
-from ucc_smartx.components.controls.learn_more import LearnMore
-from ucc_smartx.components.controls.toggle import Toggle
-from ucc_smartx.components.conf_table import ConfigurationTable
-from ucc_smartx.backend_confs import ListBackendConf
+from pytest_splunk_addon_ui_smartx.pages.page import Page
+from pytest_splunk_addon_ui_smartx.components.base_component import Selector
+from pytest_splunk_addon_ui_smartx.components.base_component import BaseComponent
+from pytest_splunk_addon_ui_smartx.components.tabs import Tab
+from pytest_splunk_addon_ui_smartx.components.entity import Entity
+from pytest_splunk_addon_ui_smartx.components.controls.button import Button
+from pytest_splunk_addon_ui_smartx.components.controls.single_select import SingleSelect
+from pytest_splunk_addon_ui_smartx.components.controls.oauth_select import OAuthSelect
+from pytest_splunk_addon_ui_smartx.components.controls.multi_select import MultiSelect
+from pytest_splunk_addon_ui_smartx.components.controls.checkbox import Checkbox
+from pytest_splunk_addon_ui_smartx.components.controls.toggle import Toggle
+from pytest_splunk_addon_ui_smartx.components.controls.textbox import TextBox
+from pytest_splunk_addon_ui_smartx.components.controls.learn_more import LearnMore
+from pytest_splunk_addon_ui_smartx.components.controls.toggle import Toggle
+from pytest_splunk_addon_ui_smartx.components.controls.message import Message
+from pytest_splunk_addon_ui_smartx.components.conf_table import ConfigurationTable
+from pytest_splunk_addon_ui_smartx.backend_confs import ListBackendConf
 from selenium.webdriver.common.by import By
 
 class AccountEntity(Entity):
@@ -30,7 +32,7 @@ class AccountEntity(Entity):
         super(AccountEntity, self).__init__(browser, entity_container, add_btn=add_btn)
 
         # Controls
-        self.name = TextBox(browser, Selector(by=By.NAME, select="name"))
+        self.name = TextBox(browser, Selector(select=".name"))
         self.environment = SingleSelect(browser, Selector(select=".custom_endpoint"), False)
         self.account_radio = Toggle(browser, Selector(select=".account_radio"))
         self.example_checkbox = Checkbox(browser, Selector(select=".account_checkbox"))
@@ -44,6 +46,7 @@ class AccountEntity(Entity):
         self.redirect_url = TextBox(browser, Selector(select=".shared-controls-textcontrol .redirect_url"))
         self.search_query  = TextBox(browser, Selector(select=" .search-query"))
         self.help_link = LearnMore(browser, Selector(select=entity_container.select + " .example_help_link a"))
+        self.title = BaseComponent(browser, Selector(select= "h4.modal-title"))
         
 class AccountPage(Page):
     """
@@ -55,6 +58,8 @@ class AccountPage(Page):
         """
         super(AccountPage, self).__init__(ucc_smartx_configs)
         account_container = Selector(select="div#account-tab")
+        self.title = Message(ucc_smartx_configs.browser, Selector(by=By.CLASS_NAME, select="tool-title"))
+        self.description = Message(ucc_smartx_configs.browser, Selector(by=By.CLASS_NAME, select="tool-description"))
         self.table = ConfigurationTable(ucc_smartx_configs.browser, account_container)
         self.entity = AccountEntity(ucc_smartx_configs.browser, account_container)
         self.backend_conf = ListBackendConf(self._get_account_endpoint(), ucc_smartx_configs.session_key)

--- a/tests/ui/Example_UccLib/custom.py
+++ b/tests/ui/Example_UccLib/custom.py
@@ -1,12 +1,12 @@
 
-from ucc_smartx.components.base_component import Selector
-from ucc_smartx.components.tabs import Tab
-from ucc_smartx.components.entity import Entity
-from ucc_smartx.components.controls.textbox import TextBox
-from ucc_smartx.components.controls.toggle import Toggle
-from ucc_smartx.components.controls.multi_select import MultiSelect
-from ucc_smartx.components.controls.learn_more import LearnMore
-from ucc_smartx.backend_confs import SingleBackendConf
+from pytest_splunk_addon_ui_smartx.components.base_component import Selector
+from pytest_splunk_addon_ui_smartx.components.tabs import Tab
+from pytest_splunk_addon_ui_smartx.components.entity import Entity
+from pytest_splunk_addon_ui_smartx.components.controls.textbox import TextBox
+from pytest_splunk_addon_ui_smartx.components.controls.toggle import Toggle
+from pytest_splunk_addon_ui_smartx.components.controls.multi_select import MultiSelect
+from pytest_splunk_addon_ui_smartx.components.controls.learn_more import LearnMore
+from pytest_splunk_addon_ui_smartx.backend_confs import SingleBackendConf
 from selenium.webdriver.common.by import By
 import time
 

--- a/tests/ui/Example_UccLib/input_page.py
+++ b/tests/ui/Example_UccLib/input_page.py
@@ -1,18 +1,20 @@
 
-from ucc_smartx.pages.page import Page
-from ucc_smartx.components.base_component import Selector
-from ucc_smartx.components.tabs import Tab
-from ucc_smartx.components.dropdown import Dropdown
-from ucc_smartx.components.entity import Entity
-from ucc_smartx.components.controls.button import Button
-from ucc_smartx.components.controls.checkbox import Checkbox
-from ucc_smartx.components.controls.learn_more import LearnMore
-from ucc_smartx.components.controls.textbox import TextBox
-from ucc_smartx.components.controls.single_select import SingleSelect
-from ucc_smartx.components.controls.multi_select import MultiSelect
-from ucc_smartx.components.input_table import InputTable
-from ucc_smartx.backend_confs import ListBackendConf
-from ucc_smartx.components.controls.toggle import Toggle
+from pytest_splunk_addon_ui_smartx.pages.page import Page
+from pytest_splunk_addon_ui_smartx.components.base_component import Selector
+from pytest_splunk_addon_ui_smartx.components.base_component import BaseComponent
+from pytest_splunk_addon_ui_smartx.components.tabs import Tab
+from pytest_splunk_addon_ui_smartx.components.dropdown import Dropdown
+from pytest_splunk_addon_ui_smartx.components.entity import Entity
+from pytest_splunk_addon_ui_smartx.components.controls.button import Button
+from pytest_splunk_addon_ui_smartx.components.controls.checkbox import Checkbox
+from pytest_splunk_addon_ui_smartx.components.controls.learn_more import LearnMore
+from pytest_splunk_addon_ui_smartx.components.controls.textbox import TextBox
+from pytest_splunk_addon_ui_smartx.components.controls.single_select import SingleSelect
+from pytest_splunk_addon_ui_smartx.components.controls.multi_select import MultiSelect
+from pytest_splunk_addon_ui_smartx.components.controls.message import Message
+from pytest_splunk_addon_ui_smartx.components.input_table import InputTable
+from pytest_splunk_addon_ui_smartx.backend_confs import ListBackendConf
+from pytest_splunk_addon_ui_smartx.components.controls.toggle import Toggle
 from selenium.webdriver.common.by import By
 
 class ExampleInputOne(Entity):
@@ -27,7 +29,7 @@ class ExampleInputOne(Entity):
         add_btn = Button(browser, Selector(select=container.select + " .add-button"))
         entity_container = Selector(select=".modal-content")
         
-        super(ExampleInputOne, self).__init__(browser, entity_container, add_btn=add_btn, wait_for=10)
+        super(ExampleInputOne, self).__init__(browser, entity_container, add_btn=add_btn)
 
         # Controls
         self.name = TextBox(browser, Selector(by=By.NAME, select="name"))
@@ -40,10 +42,12 @@ class ExampleInputOne(Entity):
         self.example_account = SingleSelect(browser, Selector(select=entity_container.select + " .account"))
         self.object = TextBox(browser, Selector(by=By.NAME, select="object"))
         self.object_fields = TextBox(browser, Selector(by=By.NAME, select="object_fields"))
-        self.order_by = TextBox(browser, Selector(by=By.NAME, select="order_by"))
+        self.order_by = TextBox(browser, Selector(select=".order_by"))
         self.query_start_date = TextBox(browser, Selector(by=By.NAME, select="start_date"))
         self.limit = TextBox(browser, Selector(by=By.NAME, select="limit"))
         self.help_link = LearnMore(browser, Selector(select=entity_container.select + " .example_help_link a"))
+        self.title = BaseComponent(browser, Selector(select= "h4.modal-title"))
+
 
 class ExampleInputTwo(Entity):
     """
@@ -57,7 +61,7 @@ class ExampleInputTwo(Entity):
         add_btn = Button(browser, Selector(select=container.select + " .add-button"))
         entity_container = Selector(select=".modal-content")
         
-        super(ExampleInputTwo, self).__init__(browser, entity_container, add_btn=add_btn, wait_for=10)
+        super(ExampleInputTwo, self).__init__(browser, entity_container, add_btn=add_btn)
 
         # Controls
         self.name = TextBox(browser, Selector(by=By.NAME, select="name"))
@@ -69,6 +73,8 @@ class ExampleInputTwo(Entity):
         self.example_radio = Toggle(browser, Selector(select=entity_container.select + " .input_two_radio"))
         self.query_start_date = TextBox(browser, Selector(by=By.NAME, select="start_date"))
         self.help_link = LearnMore(browser, Selector(select=entity_container.select + " .example_help_link a"))
+        self.title = BaseComponent(browser, Selector(select= "h4.modal-title"))
+
     
 class InputPage(Page):
     """
@@ -85,6 +91,8 @@ class InputPage(Page):
 
         input_container = Selector(select="div.inputsContainer")
         
+        self.title = Message(ucc_smartx_configs.browser, Selector(by=By.CLASS_NAME, select="tool-title"))
+        self.description = Message(ucc_smartx_configs.browser, Selector(by=By.CLASS_NAME, select="tool-description"))
         self.create_new_input = Dropdown(ucc_smartx_configs.browser, Selector(select=".add-button"))
         self.table = InputTable(ucc_smartx_configs.browser, input_container, mapping={"status": "disabled", "input_type":3})
         self.entity1 = ExampleInputOne(ucc_smartx_configs.browser, input_container)

--- a/tests/ui/test_account.py
+++ b/tests/ui/test_account.py
@@ -1,5 +1,5 @@
-from ucc_smartx.base_test import UccTester
-from ucc_smartx.backend_confs import BackendConf
+from pytest_splunk_addon_ui_smartx.base_test import UccTester
+from pytest_splunk_addon_ui_smartx.backend_confs import BackendConf
 from .Example_UccLib.account import AccountPage
 from .Example_UccLib.input_page import InputPage
 
@@ -132,6 +132,55 @@ class TestAccount(UccTester):
         account.table.clean_filter()
 
     @pytest.mark.account
+    # Verifies the default number of rows in the table
+    def test_account_default_rows_in_table(self, ucc_smartx_configs):
+        account = AccountPage(ucc_smartx_configs)   
+        number_of_rows = account.table.get_row_count()
+        assert number_of_rows == 0 
+
+    @pytest.mark.account
+    # Verifies the title and description of the page
+    def test_account_title_and_description(self, ucc_smartx_configs):
+        account = AccountPage(ucc_smartx_configs)
+        assert account.title.wait_to_display() == "Configuration"
+        assert account.description.wait_to_display() == "Set up your add-on"
+
+    @pytest.mark.account
+    # Verifies the title of the 'Add Entity'
+    def test_account_add_valid_title(self, ucc_smartx_configs):
+        account = AccountPage(ucc_smartx_configs)
+        account.entity.open()
+        assert account.entity.title.container.get_attribute('textContent').strip() == "Add Account"
+
+    @pytest.mark.account
+    # Verifies the title of the 'Edit Entity'
+    def test_account_edit_valid_title(self, ucc_smartx_configs, add_account):
+        account = AccountPage(ucc_smartx_configs)
+        account.table.edit_row(ACCOUNT_CONFIG["name"])
+        assert account.entity.title.container.get_attribute('textContent').strip() == "Update Account"
+
+    @pytest.mark.account
+    # Verifies the title of the 'Clone Entity'
+    def test_account_clone_valid_title(self, ucc_smartx_configs, add_account):
+        account = AccountPage(ucc_smartx_configs)
+        account.table.clone_row(ACCOUNT_CONFIG["name"])
+        assert account.entity.title.container.get_attribute('textContent').strip() == "Clone Account"
+
+    @pytest.mark.account
+    # Verifies the title of the 'Delete Entity'
+    def test_account_delete_valid_title(self, ucc_smartx_configs, add_account):
+        account = AccountPage(ucc_smartx_configs)
+        account.table.delete_row(ACCOUNT_CONFIG["name"], prompt_msg=True)
+        assert account.entity.title.container.get_attribute('textContent').strip() == "Delete Confirmation"
+
+    @pytest.mark.account
+    # Verifies the prompt message of the 'Delete Entity'
+    def test_account_delete_valid_prompt_message(self, ucc_smartx_configs, add_account):
+        account = AccountPage(ucc_smartx_configs)
+        prompt_message = account.table.delete_row(ACCOUNT_CONFIG["name"], prompt_msg=True)
+        assert prompt_message == 'Are you sure you want to delete "{}" ? Ensure that no input is configured with "{}" as this will stop data collection for that input.'.format(ACCOUNT_CONFIG["name"],ACCOUNT_CONFIG["name"])
+
+    @pytest.mark.account
     # Verifies required field username
     def test_account_required_field_username(self, ucc_smartx_configs):
         account = AccountPage(ucc_smartx_configs)
@@ -148,6 +197,14 @@ class TestAccount(UccTester):
         assert account.entity.save(expect_error=True) == 'Field Password is required'
 
     @pytest.mark.account
+    # Verifies if the password field is masked or not in the Textbox
+    def test_account_encrypted_field_password(self, ucc_smartx_configs):
+        account = AccountPage(ucc_smartx_configs)
+        account.entity.open()
+        textbox_type = account.entity.password.get_type()
+        assert textbox_type == 'password'
+
+    @pytest.mark.account
     # Verifies required field name
     def test_account_required_field_name(self, ucc_smartx_configs):
         account = AccountPage(ucc_smartx_configs)
@@ -155,6 +212,14 @@ class TestAccount(UccTester):
         account.entity.username.set_value(ACCOUNT_CONFIG["username"])
         account.entity.password.set_value(ACCOUNT_CONFIG["password"])
         assert account.entity.save(expect_error=True) == 'Field Name is required'
+
+    @pytest.mark.account
+    # Verifies help text for the field name
+    def test_account_help_text_name(self, ucc_smartx_configs):
+        account = AccountPage(ucc_smartx_configs)
+        account.entity.open()
+        help_text = account.entity.name.get_help_text()
+        assert help_text == 'Enter a unique name for this account.'
 
     @pytest.mark.account
     # Verifies required field example environment
@@ -195,6 +260,15 @@ class TestAccount(UccTester):
         account.entity.multiple_select.select("Option One")
         account.entity.client_id.set_value("TestClientId")
         assert account.entity.save(expect_error=True) == 'Field Client Secret is required'
+
+    @pytest.mark.account
+    # Verifies if the password field is masked or not in the Textbox
+    def test_account_encrypted_field_client_secret(self, ucc_smartx_configs):
+        account = AccountPage(ucc_smartx_configs)
+        account.entity.open()
+        account.entity.auth_key.select('OAuth 2.0 Authentication')
+        textbox_type = account.entity.client_secret.get_type()
+        assert textbox_type == 'password'
 
     @pytest.mark.account
     # Verifies whether adding special characters, number in starting of name field displays validation error

--- a/tests/ui/test_custom.py
+++ b/tests/ui/test_custom.py
@@ -1,4 +1,4 @@
-from ucc_smartx.base_test import UccTester
+from pytest_splunk_addon_ui_smartx.base_test import UccTester
 from .Example_UccLib.custom import Custom
 import pytest
 import time

--- a/tests/ui/test_input.py
+++ b/tests/ui/test_input.py
@@ -1,5 +1,5 @@
-from ucc_smartx.base_test import UccTester
-from ucc_smartx.pages.logging import Logging
+from pytest_splunk_addon_ui_smartx.base_test import UccTester
+from pytest_splunk_addon_ui_smartx.pages.logging import Logging
 from .Example_UccLib.account import AccountPage
 from .Example_UccLib.input_page import InputPage
 import pytest
@@ -363,6 +363,14 @@ class TestInput(UccTester):
         assert input_page.entity1.order_by.get_value() == default_order_by
 
     @pytest.mark.input
+    # Verifies help text for the field name
+    def test_example_input_one_help_text_order_by(self, ucc_smartx_configs):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.create_new_input.select("Example Input One")
+        help_text = input_page.entity1.order_by.get_help_text()
+        assert help_text == 'The datetime field by which to query results in ascending order for indexing.'
+
+    @pytest.mark.input
     # Verifies whether adding wrong format, Query Start Date field displays validation error
     def test_example_input_one_valid_input_query_start_date(self, ucc_smartx_configs):
         input_page = InputPage(ucc_smartx_configs)
@@ -682,6 +690,42 @@ class TestInput(UccTester):
         assert input_page.entity1.save(expect_error=True) == "Name {} is already in use".format(input_name)
         assert input_page.entity1.close_error()
 
+    @pytest.mark.input
+    # Verifies the title of the 'Add Entity'
+    def test_example_input_one_add_valid_title(self, ucc_smartx_configs):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.create_new_input.select("Example Input One")
+        assert input_page.entity1.title.container.get_attribute('textContent').strip() == "Add Example Input One"
+
+    @pytest.mark.input
+    # Verifies the title of the 'Edit Entity'
+    def test_example_input_one_edit_valid_title(self, ucc_smartx_configs, add_input_one):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.table.edit_row("dummy_input_one")
+        assert input_page.entity1.title.container.get_attribute('textContent').strip() == "Update Example Input One"
+
+    @pytest.mark.input
+    # Verifies the title of the 'Clone Entity'
+    def test_example_input_one_clone_valid_title(self, ucc_smartx_configs, add_input_one):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.table.clone_row("dummy_input_one")
+        assert input_page.entity1.title.container.get_attribute('textContent').strip() == "Clone Example Input One"
+
+    @pytest.mark.input
+    # Verifies the title of the 'Delete Entity'
+    def test_example_input_one_delete_valid_title(self, ucc_smartx_configs, add_input_one):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.table.delete_row("dummy_input_one", prompt_msg=True)
+        assert input_page.entity1.title.container.get_attribute('textContent').strip() == "Delete Confirmation"
+
+    @pytest.mark.input
+    # Verifies the prompt message of the 'Delete Entity'
+    def test_example_input_one_delete_valid_prompt_message(self, ucc_smartx_configs, add_input_one):
+        input_page = InputPage(ucc_smartx_configs)
+        input_name = "dummy_input_one"
+        prompt_message = input_page.table.delete_row("dummy_input_one", prompt_msg=True)
+        assert prompt_message == 'Are you sure you want to delete "{}" ?'.format(input_name)
+    
 
 
     ############################
@@ -795,6 +839,20 @@ class TestInput(UccTester):
         assert input_page.table.switch_to_page(2)
         assert input_page.table.switch_to_prev()
         assert input_page.table.switch_to_next()
+
+    @pytest.mark.input
+    # Verifies the title and description of the page
+    def test_inputs_title_and_description(self, ucc_smartx_configs):
+        input_page = InputPage(ucc_smartx_configs)
+        assert input_page.title.wait_to_display() == "Inputs"
+        assert input_page.description.wait_to_display() == "Manage your data inputs"
+
+    @pytest.mark.input
+    # Verifies the default number of rows in the table
+    def test_inputs_default_rows_in_table(self, ucc_smartx_configs):
+        input_page = InputPage(ucc_smartx_configs)   
+        number_of_rows = input_page.table.get_row_count()
+        assert number_of_rows == 0
 
     ##########################################
     #### TEST CASES FOR EXAMPLE INPUT TWO ####
@@ -913,6 +971,14 @@ class TestInput(UccTester):
         for each in selected_values:
             input_page.entity2.example_multiple_select.select(each)
         assert input_page.entity2.example_multiple_select.get_values() == selected_values
+
+    @pytest.mark.input
+    # Verifies help text for the field name
+    def test_example_input_two_help_text_example_multiple_select(self, ucc_smartx_configs):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.create_new_input.select("Example Input Two")
+        help_text = input_page.entity2.example_multiple_select.get_help_text()
+        assert help_text == 'This is an example multipleSelect for input two entity'    
 
     @pytest.mark.input
     # Verifies Check in example checkbox in Example Input Two
@@ -1219,3 +1285,40 @@ class TestInput(UccTester):
         input_page.entity2.name.set_value(input_name)
         assert input_page.entity2.save(expect_error=True) == "Name {} is already in use".format(input_name)
         assert input_page.entity2.close_error()
+
+
+    @pytest.mark.input
+    # Verifies the title of the 'Add Entity'
+    def test_example_input_two_add_valid_title(self, ucc_smartx_configs):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.create_new_input.select("Example Input Two")
+        assert input_page.entity2.title.container.get_attribute('textContent').strip() == "Add Example Input Two"
+
+    @pytest.mark.input
+    # Verifies the title of the 'Edit Entity'
+    def test_example_input_two_edit_valid_title(self, ucc_smartx_configs, add_input_two):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.table.edit_row("dummy_input_two")
+        assert input_page.entity2.title.container.get_attribute('textContent').strip() == "Update Example Input Two"
+
+    @pytest.mark.input
+    # Verifies the title of the 'Clone Entity'
+    def test_example_input_two_clone_valid_title(self, ucc_smartx_configs, add_input_two):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.table.clone_row("dummy_input_two")
+        assert input_page.entity2.title.container.get_attribute('textContent').strip() == "Clone Example Input Two"
+
+    @pytest.mark.input
+    # Verifies the title of the 'Delete Entity'
+    def test_example_input_two_delete_valid_title(self, ucc_smartx_configs, add_input_two):
+        input_page = InputPage(ucc_smartx_configs)
+        input_page.table.delete_row("dummy_input_two", prompt_msg=True)
+        assert input_page.entity2.title.container.get_attribute('textContent').strip() == "Delete Confirmation"
+
+    @pytest.mark.input
+    # Verifies the prompt message of the 'Delete Entity'
+    def test_example_input_two_delete_valid_prompt_message(self, ucc_smartx_configs, add_input_two):
+        input_page = InputPage(ucc_smartx_configs)
+        input_name = "dummy_input_two"
+        prompt_message = input_page.table.delete_row("dummy_input_two", prompt_msg=True)
+        assert prompt_message == 'Are you sure you want to delete "{}" ?'.format(input_name)

--- a/tests/ui/test_logging.py
+++ b/tests/ui/test_logging.py
@@ -1,5 +1,5 @@
-from ucc_smartx.base_test import UccTester
-from ucc_smartx.pages.logging import Logging
+from pytest_splunk_addon_ui_smartx.base_test import UccTester
+from pytest_splunk_addon_ui_smartx.pages.logging import Logging
 import pytest
 import time
 import re

--- a/tests/ui/test_proxy.py
+++ b/tests/ui/test_proxy.py
@@ -122,6 +122,13 @@ class TestProxy(UccTester):
         assert proxy.close_error()
 
     @pytest.mark.proxy
+    # Verifies if the password field is masked or not in the Textbox
+    def test_proxy_encrypted_field_password(self, ucc_smartx_configs):
+        proxy = Proxy(ucc_smartx_configs, TA_NAME, TA_CONF)
+        textbox_type = proxy.password.get_type()
+        assert textbox_type == 'password'
+
+    @pytest.mark.proxy
     # Verifies the proxy is saved properly in frontend after saving it
     def test_proxy_frontend_validation(self, ucc_smartx_configs):
         proxy = Proxy(ucc_smartx_configs, TA_NAME, TA_CONF)

--- a/tests/ui/test_proxy.py
+++ b/tests/ui/test_proxy.py
@@ -1,5 +1,5 @@
-from ucc_smartx.base_test import UccTester
-from ucc_smartx.pages.proxy import Proxy
+from pytest_splunk_addon_ui_smartx.base_test import UccTester
+from pytest_splunk_addon_ui_smartx.pages.proxy import Proxy
 import pytest
 import time
 import re


### PR DESCRIPTION
As a part of this PR, the following has been included:

1. Updated imports in test case files and other necessary files.

2. Added test cases for the following scenarios in both account and inputs page.

- Encrypted Fields

- Page titles and Entity Titles

- Help Text validation for fields

- Total number of rows present by default in table


