### PR TITLE
Skip the UI tests if the SauceConnect is not running

### DIFF
--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -38,7 +38,7 @@ else
         wget --retry-connrefused --no-check-certificate -T 10 sauceconnect:4445 
         sauce_connect_connection=$?
         echo "Sauce Connect Status:$sauce_connect_connection"
-        [ "$sauce_connect_connection" == "4" ] && echo "SauceConnect is not running. exiting the tests..." && exit 1
+        [ "$sauce_connect_connection" -eq "4" ] && echo "SauceConnect is not running. Exiting the tests...." && exit 1
         echo Test Args $@ --reruns=${RERUN_COUNT} --browser=${TEST_BROWSER} ${TEST_SET}
         pytest $@ --reruns=${RERUN_COUNT} --browser=${TEST_BROWSER} \
         --reportportal -o "rp_endpoint=${RP_ENDPOINT}" -o "rp_launch_attributes=${RP_LAUNCH_ATTRIBUTES}" \

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -36,7 +36,9 @@ else
     else
         echo "Check Saucelab connection..."
         wget --retry-connrefused --no-check-certificate -T 10 sauceconnect:4445 
-        [ "$?" == "4" ] && echo "SauceConnect is not running. exiting the tests..." && exit 1
+        sauce_connect_connection=$?
+        echo "Sauce Connect Status:$sauce_connect_connection"
+        [ "$sauce_connect_connection" == "4" ] && echo "SauceConnect is not running. exiting the tests..." && exit 1
         echo Test Args $@ --reruns=${RERUN_COUNT} --browser=${TEST_BROWSER} ${TEST_SET}
         pytest $@ --reruns=${RERUN_COUNT} --browser=${TEST_BROWSER} \
         --reportportal -o "rp_endpoint=${RP_ENDPOINT}" -o "rp_launch_attributes=${RP_LAUNCH_ATTRIBUTES}" \

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -36,6 +36,7 @@ else
     else
         echo "Check Saucelab connection..."
         wget --retry-connrefused --no-check-certificate -T 10 sauceconnect:4445 
+        [ "$?" == "4" ] && echo "SauceConnect is not running. exiting the tests..." && exit 1
         echo Test Args $@ --reruns=${RERUN_COUNT} --browser=${TEST_BROWSER} ${TEST_SET}
         pytest $@ --reruns=${RERUN_COUNT} --browser=${TEST_BROWSER} \
         --reportportal -o "rp_endpoint=${RP_ENDPOINT}" -o "rp_launch_attributes=${RP_LAUNCH_ATTRIBUTES}" \


### PR DESCRIPTION
If SauceConnect service is not running

```
test_1          | wget: unable to resolve host address ‘sauceconnect’
test_1          | Sauce Connect Status:4
test_1          | SauceConnect is not running. Exiting the tests....
```

If it's running
```
Saving to: ‘index.html’
test_1          | 
test_1          |      0K                                                        1.51M=0s
test_1          | 
test_1          | 2020-11-11 12:57:01 (1.51 MB/s) - ‘index.html’ saved [17]
test_1          | 
test_1          | Sauce Connect Status:0
test_1          | Test Args --reruns=3 --browser=chrome tests/ui
test_1          | ============================= test session starts ==============================
```