### PR TITLE
Test: UI test failure resolved

### DIFF
--- a/.pytest.expect
+++ b/.pytest.expect
@@ -3,4 +3,6 @@ pytest-expect file v1
 u'tests/knowledge/test_addon.py::Test_App::test_tags[eventtype="UCC_NOT_GENERATED"::tag::notalert]': FAIL
 u'tests/knowledge/test_addon.py::Test_App::test_eventtype[eventtype::UCC_NOT_GENERATED]': FAIL
 u'tests/ui/test_splunk_ta_example_addon_account.py::TestAccount::test_account_delete_account_in_use': FAIL
+u'tests/ui/test_splunk_ta_example_addon_account.py::TestAccount::test_account_basic_fields_label_entity': FAIL
+u'tests/ui/test_splunk_ta_example_addon_account.py::TestAccount::test_account_oauth_fields_label_entity': FAIL
 u'tests/ui/test_splunk_ta_example_addon_input.py::TestInput::test_inputs_delete_enabled_input': FAIL

--- a/.pytest.expect.baseline
+++ b/.pytest.expect.baseline
@@ -3,4 +3,6 @@ pytest-expect file v1
 u'tests/knowledge/test_addon.py::Test_App::test_tags[eventtype="UCC_NOT_GENERATED"::tag::notalert]': FAIL
 u'tests/knowledge/test_addon.py::Test_App::test_eventtype[eventtype::UCC_NOT_GENERATED]': FAIL
 u'tests/ui/test_splunk_ta_example_addon_account.py::TestAccount::test_account_delete_account_in_use': FAIL
+u'tests/ui/test_splunk_ta_example_addon_account.py::TestAccount::test_account_basic_fields_label_entity': FAIL
+u'tests/ui/test_splunk_ta_example_addon_account.py::TestAccount::test_account_oauth_fields_label_entity': FAIL
 u'tests/ui/test_splunk_ta_example_addon_input.py::TestInput::test_inputs_delete_enabled_input': FAIL

--- a/tests/ui/test_splunk_ta_example_addon_custom.py
+++ b/tests/ui/test_splunk_ta_example_addon_custom.py
@@ -328,16 +328,6 @@ class TestCustom(UccTester):
 
     @pytest.mark.forwarder
     @pytest.mark.custom
-    def test_custom_default_value_test_radio(self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper):
-        """ This test case checks default value of test radio"""
-        custom = Custom(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
-        self.assert_util(
-            custom.test_radio.get_value,
-            r"Yes"
-            )
-
-    @pytest.mark.forwarder
-    @pytest.mark.custom
     def test_custom_select_value_test_radio(self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper):
         """ This test case checks selected value of test radio"""
         custom = Custom(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)

--- a/tests/ui/test_splunk_ta_example_addon_input.py
+++ b/tests/ui/test_splunk_ta_example_addon_input.py
@@ -796,35 +796,35 @@ class TestInput(UccTester):
         input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         input_page.create_new_input.select("Example Input Two")
         self.assert_util(
-            input_page.entity1.name.get_input_label,
+            input_page.entity2.name.get_input_label,
             'Name'
             )
         self.assert_util(
-            input_page.entity1.interval.get_input_label,
+            input_page.entity2.interval.get_input_label,
             'Interval'
             )
         self.assert_util(
-            input_page.entity1.index.get_input_label,
+            input_page.entity2.index.get_input_label,
             'Index'
             )
         self.assert_util(
-            input_page.entity1.example_account.get_input_label,
+            input_page.entity2.example_account.get_input_label,
             'Example Account'
             )
         self.assert_util(
-            input_page.entity1.multiple_select_test.get_input_label,
-            'Multiple Select Test'
+            input_page.entity2.example_multiple_select.get_input_label,
+            'Example Multiple Select'
             )
         self.assert_util(
-            input_page.entity1.example_checkbox.get_input_label,
+            input_page.entity2.example_checkbox.get_input_label,
             'Example Checkbox'
             )
         self.assert_util(
-            input_page.entity1.example_radio.get_input_label,
+            input_page.entity2.example_radio.get_input_label,
             'Example Radio'
             )
         self.assert_util(
-            input_page.entity1.query_start_date.get_input_label,
+            input_page.entity2.query_start_date.get_input_label,
             'Query Start Date ?'
             )
             


### PR DESCRIPTION
After updating SmartX assert_util method. 4 tests failed.  This PR contains fixes/exceptions.

 
test_account_basic_fields_label_entity : Failing due to https://jira.splunk.com/browse/INFRA-29177. 
test_account_oauth_fields_label_entity: Failing due to https://jira.splunk.com/browse/INFRA-29177.
test_custom_default_value_test_radio: The radio component has no default value. Removed. 
test_example_input_two_fields_label_entity: Was using entity-1's components. Fixed. 